### PR TITLE
修复插件不编译直接安装时的错误

### DIFF
--- a/app/src/main/java/io/github/mzdluo123/mirai/android/activity/PluginImportActivity.kt
+++ b/app/src/main/java/io/github/mzdluo123/mirai/android/activity/PluginImportActivity.kt
@@ -109,7 +109,7 @@ class PluginImportActivity : AppCompatActivity() {
                         copyToFileDir(
                             uri,
                             name,
-                            this@PluginImportActivity.getExternalFilesDir("files/plugins")!!.absolutePath
+                            this@PluginImportActivity.getExternalFilesDir("plugins")!!.absolutePath
                         )
                     }
                     dialog.dismiss()


### PR DESCRIPTION
getExternalFilesDir已经包含files文件夹了