### PR TITLE
捕获runCmd抛出的DeadObjectException

### DIFF
--- a/app/src/main/java/io/github/mzdluo123/mirai/android/ui/console/ConsoleFragment.kt
+++ b/app/src/main/java/io/github/mzdluo123/mirai/android/ui/console/ConsoleFragment.kt
@@ -178,7 +178,12 @@ class ConsoleFragment : Fragment() {
             if (!command.startsWith("/")) {
                 command = "/$command"
             }
-            conn.botService.runCmd(command)
+            try {
+                conn.botService.runCmd(command)
+            }
+            catch (e: DeadObjectException) {
+                //pass
+            }
         }
         command_input.text.clear()
     }


### PR DESCRIPTION
不然每次Mirai退出后点一下命令回车键就会抛异常